### PR TITLE
add: interleave

### DIFF
--- a/src/array.js
+++ b/src/array.js
@@ -57,7 +57,7 @@ dtm.array = function () {
         'split', 'join',
         'pitchquantize', 'pq', 'mtof', 'ftom',
         'ntob', 'bton', 'itob', 'btoi', 'btot', 'ttob',
-        'size'
+        'size', 'interleave'
     ];
 
     var params = {
@@ -3205,6 +3205,21 @@ dtm.array = function () {
     };
 
 
+    /**
+     * Interleaves two arrays
+     * @param arrIn {dtm.array}
+     * @param depth1 {integer}
+     * @param depth2 {integer}
+     * @returns {dtm.array}
+     */
+    array.interleave = function (arrIn,depth1,depth2) {
+        var d1 = depth1 || 1
+        var d2 = depth2 || 1
+        return array.set(dtm.transform.interleave(array.get(), arrIn.get(), d1, d2));
+    };
+
+
+
     /* aliases */
 
     array.histo = array.histogram;
@@ -3259,6 +3274,7 @@ dtm.array = function () {
     // set the array content here
     array.set.apply(this, arguments);
     return array;
+
 };
 
 dtm.d = dtm.data = dtm.a = dtm.array;

--- a/src/transform.js
+++ b/src/transform.js
@@ -1099,7 +1099,35 @@ dtm.transform = {
         return morphFixed(dtm.transform.fit(srcArr, resLen, interp), dtm.transform.fit(tgtArr, resLen), morphIdx);
     },
 
-    interleave: function (srcArr, tgtArr) {
+    /**
+        Interleave two arrays.
+        If input arrays are different lengths, the shorter will repeat.
+        @function module:transform#interleave
+        @param arr1 {array} 
+        @param arr2 {array}
+        @param [depth1=1] {integer}
+        @param [depth2=1] {integer}
+     */
+    interleave: function (arr1, arr2, depth1, depth2) {
+
+        var result = []
+        var newlength = Math.max(arr1.length,arr2.length) * (depth1 + depth2)
+        var index1 = 0
+        var index2 = 0
+        for (var i=0;i<newlength;i++) {
+            for (j=0;j<depth1;j++) {
+                var val = arr1[index1%arr1.length]
+                index1++
+                result.push( val )
+            }
+            for (j=0;j<depth2;j++) {
+                var val = arr2[index2%arr2.length]
+                index2++
+                result.push( val )
+            }
+        }
+        return result
+
     },
 
 

--- a/src/transform_worker.js
+++ b/src/transform_worker.js
@@ -1004,7 +1004,35 @@ dtm.transform = {
         return morphFixed(dtm.transform.fit(srcArr, resLen, interp), dtm.transform.fit(tgtArr, resLen), morphIdx);
     },
 
-    interleave: function (srcArr, tgtArr) {
+    /**
+        Interleave two arrays.
+        If input arrays are different lengths, the shorter will repeat.
+        @function module:transform#interleave
+        @param arr1 {array} 
+        @param arr2 {array}
+        @param [depth1=1] {integer}
+        @param [depth2=1] {integer}
+     */
+    interleave: function (arr1, arr2, depth1, depth2) {
+
+        var result = []
+        var newlength = Math.max(arr1.length,arr2.length) * (depth1 + depth2)
+        var index1 = 0
+        var index2 = 0
+        for (var i=0;i<newlength;i++) {
+            for (j=0;j<depth1;j++) {
+                var val = arr1[index1%arr1.length]
+                index1++
+                result.push( val )
+            }
+            for (j=0;j<depth2;j++) {
+                var val = arr2[index2%arr2.length]
+                index2++
+                result.push( val )
+            }
+        }
+        return result
+
     },
 
 


### PR DESCRIPTION
This is an interleave function I added to my fork. It may be different than what you are planning! There are a lot of options for interleaving. But I wanted to share this in case it is similar to what you  expected.

This approach allows an optional ‘depth’ for each array, which is the number of items from that array that are used before alternating.

Given:
```
a = dtm.data(1,2,3,4)
b = dtm.data(5)
```

Example 1:
```
a.interleave(b)
// => [1,5,2,5,3,5,4,5]
```

Example 2:
```
a.interleave(b,2)
// array1 depth is now 2
// => [1,2,5,3,4,5]
```

Example 3:
```
a.interleave(b,1,3)
// array1 depth is 1
// array2 depth is 3
// => [1,5,5,5,2,5,5,5,3,5,5,5,4,5,5,5]
```

